### PR TITLE
Add gulpfile for browserifing the code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,28 @@
-node_modules
+# --------------------
+# OSX Files
+# --------------------
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
+
+# --------------------
+# Node Files
+# --------------------
+.nodemonignore
+npm-debug.log
+node_modules/
+
+# --------------------
+# App Files
+# --------------------
+dist/
+
+# --------------------
+# vim Files
+# --------------------
+*.swp
+*.vim

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,69 @@
+'use strict';
+
+var gulp = require('gulp');
+var concat = require('gulp-concat');
+var browserify = require('browserify');
+var replace = require('gulp-replace');
+var fs = require('fs');
+var uglify = require('gulp-uglify');
+var rename = require('gulp-rename');
+var del = require('del');
+
+/**
+ * Concatenate all dictionaries
+ */
+gulp.task('concat', function() {
+  return gulp.src('./data/*.txt')
+  .pipe(concat('data.txt'))
+  .pipe(gulp.dest('./dist/tmp/'));
+});
+
+/**
+ * Copy all files in libs
+ */
+gulp.task('copy', function() {
+  return gulp.src(['./lib/*.js']) 
+  .pipe(gulp.dest('./dist/tmp'));
+});
+
+/**
+ * Replace the dynamic files path of dictionaries with the static concatenated file
+ */
+gulp.task('replace', ['copy'], function() {
+  return gulp.src('./dist/tmp/dict.js')    
+  .pipe(replace(/files = this\.sortuniq\(this\.flatten\(files\.map\(function\(x\)\{return glob\.sync\(x\)\}\)\)\)/, ''))
+  .pipe(replace(/files.length/, 1))
+  .pipe(replace(/files\[i\]/, '"./dist/tmp/data.txt"'))
+  .pipe(gulp.dest('./dist/tmp'));
+});
+
+/**
+ * Browserify the wordcut.js and export it as "wordcut"
+ */
+gulp.task('brfs', ['copy', 'concat', 'replace'], function() {
+  var file = './dist/tmp/wordcut.js';
+  return browserify(file)
+  .transform('brfs')
+  .require(file, {expose: 'wordcut'})
+  .bundle()
+  .pipe(fs.createWriteStream('./dist/wordcut.js'));
+});
+
+/**
+ * Minify
+ */
+gulp.task('min', ['brfs'], function() {
+  return gulp.src('./dist/wordcut.js')
+  .pipe(uglify())
+  .pipe(rename('wordcut.min.js'))
+  .pipe(gulp.dest('./dist')); 
+});
+
+/**
+ * Remove tmp files
+ */
+gulp.task('rm', ['brfs'], function() {
+  return del(['./dist/tmp']);
+});
+
+gulp.task('build', ['copy', 'concat', 'replace', 'brfs', 'min', 'rm']);

--- a/lib/dict.js
+++ b/lib/dict.js
@@ -1,8 +1,8 @@
-var fs = require("fs"),
-  LEFT = 0,
-  RIGHT = 1,
-  path = require("path"),
-  glob = require("glob")
+var fs = require("fs");
+var LEFT = 0;
+var RIGHT = 1;
+var path = require("path");
+var glob = require("glob");
 
 var WordcutDict = {
 

--- a/package.json
+++ b/package.json
@@ -49,5 +49,15 @@
   },
   "scripts": {
     "test": "mocha test"
+  },
+  "devDependencies": {
+    "brfs": "^1.4.1",
+    "browserify": "^11.2.0",
+    "del": "^2.0.2",
+    "gulp": "^3.9.0",
+    "gulp-concat": "^2.6.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.5.4",
+    "gulp-uglify": "^1.4.1"
   }
 }


### PR DESCRIPTION
จากหัวข้อที่ #9 ครับ ผมทำการเพิ่ม Gulp เพื่อให้สามารถทำการ Browserify โค้ดให้ใช้งานได้ในฝั่ง Frontend โดยสามารถใช้คำสั่ง: 

`gulp build`

ผลลัพธ์ที่ได้คือไฟล์ 2 ไฟล์ที่ประกอบด้วย `wordcut.js` และ `wordcut.min.js` ที่อยู่ในโฟเดอร์ `dist` : 

```
dist/
--wordcut.js
--wordcut.min.js
```

ในฝั่ง Browser สามารถเรียกใช้งานได้โดยใช้:

```html
<script src="/path/to/the/file/wordcut.min.js"></script>
<script>
    var wordcut = require('wordcut');
    wordcut.init();
    wordcut.cut('กากา');
</script>
```
---
**TODO**
- เพิ่ม bower.json เพื่อให้สามารถลงผ่าน bower ได้
- Update README.md