### PR TITLE
use `util` instead of `sys`

### DIFF
--- a/lib/wordcut.js
+++ b/lib/wordcut.js
@@ -1,4 +1,4 @@
-var sys = require("sys")
+var util = require("util")
   , WordcutDict = require("./dict")
   , WordcutCore = require("./wordcut_core")
   , PathInfoBuilder = require("./path_info_builder")


### PR DESCRIPTION
Q: why you create `sys`, but not use in anywhere?